### PR TITLE
Support lowercase query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.7
+- Fixed error when using lowercased in-REPL commands.
+
 ## 1.4.6
 - Updated incorrect warning message on CREATE/DROP DATABASE commands.
 - Removed unused validation function - validation of disallowed queries is now handled by D1.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "d1-console",
-	"version": "1.4.6",
+	"version": "1.4.7",
 	"license": "GPL-3.0-or-later",
 	"description": "A full query console for Cloudflare's D1 database product.",
 	"author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const evalFunction = async (
 			}
 
 			if (upperCommand.startsWith("USE")) {
-				const databaseName = command.match(/USE\s+(.*)/);
+				const databaseName = command.match(/USE\s+(.*)/i);
 				if (databaseName == null) {
 					console.error(chalk.redBright("Invalid USE statement."));
 					return;
@@ -94,14 +94,14 @@ const evalFunction = async (
 					queryRepl.setPrompt(`${foundDatabase.name} > `);
 				}
 			} else if (upperCommand.startsWith("CREATE DATABASE")) {
-				const databaseName = command.match(/CREATE DATABASE\s+(.*)/);
+				const databaseName = command.match(/CREATE DATABASE\s+(.*)/i);
 				if (databaseName == null) {
 					console.error(chalk.redBright("Invalid CREATE DATABASE statement."));
 					return;
 				}
 				await createDatabase(databaseName[1]);
 			} else if (upperCommand.startsWith("DROP DATABASE")) {
-				const databaseName = command.match(/DROP DATABASE\s+(.*)/);
+				const databaseName = command.match(/DROP DATABASE\s+(.*)/i);
 				if (databaseName == null) {
 					console.error(chalk.redBright("Invalid DROP DATABASE statement."));
 					return;


### PR DESCRIPTION
Hi!

Lower case letters would have resulted in Invalid USE statement.

```sql
D1 > use sample-db;
Invalid USE statement.
```

It would be nice if lower case letters could also be used.